### PR TITLE
refactor: set a milestone instead of tag

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -32,12 +32,21 @@ async function getJiraTicketAndUpdatePr(pr) {
   const type = ticket.fields?.issuetype?.name.toLowerCase() == 'bug' ? 'bug' : 'feature';
   const fixVersion = ticket.fields?.fixVersions[0]?.name;
   const labels = [type];
-  if (fixVersion) labels.push(fixVersion);
+
   await octokit.rest.issues.addLabels({
     owner: config.repo_owner,
     repo: config.repo,
     issue_number: pr.id,
     labels: labels,
+  });
+
+  if fixVersion == "0" { return; } // Do not set milestone if fix veresion is 0
+
+  await octokit.rest.issues.update({
+    owner: config.repo_owner,
+    repo: config.repo,
+    issue_number: pr.id,
+    milestone: fixVersion,
   });
 }
 


### PR DESCRIPTION
To avoid using 2 patch request, we could [fetch the issue tags first](https://docs.github.com/en/rest/issues/labels#list-labels-for-an-issue), then update the issue including all previous tags + bug/feature (if it doesn't have it already)

